### PR TITLE
Add parcel-plugin-markdown-string

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -43,6 +43,7 @@
 
 - [Pug](https://github.com/Ty3uK/parcel-plugin-pug) - Pug template support.
 - [Markdown](https://github.com/gongpeione/parcel-plugin-markdown) - Plugin for markdown support.
+- [Markdown String](https://github.com/jaywcjlove/parcel-plugin-markdown-string) - Plugin for markdown string support.
 - [Mustache](https://github.com/suuzee/parcel-plugin-mustache) - Plugin for Mustache template support.
 - [Nunjucks](https://github.com/devmattrick/parcel-plugin-nunjucks) - Plugin to compile Nunjucks templates.
 - [Handlebars](https://github.com/TheBlackBolt/parcel-plugin-handlebars) - Plugin to compile handlebars templates.


### PR DESCRIPTION
Parcel plugin [parcel-plugin-markdown-string](https://github.com/jaywcjlove/parcel-plugin-markdown-string) for loader markdown string.
Markdownss does not do any conversion

```js
import MarkdownString from './Markdown.md';
console.log(MarkdownString)
// => Output markdown string.
```