### PR TITLE
Adding parcel-plugin-static-files-copy

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -81,6 +81,7 @@
 - [SW Precache](https://github.com/cyyyu/parcel-plugin-sw-precache) Plugin to generate a service worker file that will precache resources so they work offline. (PWA)
 - [react-native-web](https://github.com/dalcib/parcel-plugin-react-native-web) - Plugin that enables [react-native-web](https://github.com/necolas/react-native-web) support.
 - [web-extension](https://github.com/kevincharm/parcel-plugin-web-extension) - Plugin that enables to use a WebExtension `manifest.json` as an entry point.
+- [Static Files Copy](https://github.com/elwin013/parcel-plugin-static-files-copy) - Plugin that copy static files into bundle directory.
 
 ## Integration with other languages, frameworks
 


### PR DESCRIPTION
Simple plugin to copy files from static directory to bundle directory [1] - currently Minimal Viable Product, but in next few days will be improved (see issues for more info).

[1] [Static Files Copy](https://github.com/elwin013/parcel-plugin-static-files-copy)