### PR TITLE
Add parcel-plugin-inliner

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -82,6 +82,7 @@
 - [react-native-web](https://github.com/dalcib/parcel-plugin-react-native-web) - Plugin that enables [react-native-web](https://github.com/necolas/react-native-web) support.
 - [web-extension](https://github.com/kevincharm/parcel-plugin-web-extension) - Plugin that enables to use a WebExtension `manifest.json` as an entry point.
 - [Static Files Copy](https://github.com/elwin013/parcel-plugin-static-files-copy) - Plugin that copy static files into bundle directory.
+- [Inliner](https://github.com/shff/parcel-plugin-inliner) - Inlines all your CSS, JS and images in a single HTML file. Great for small websites.
 
 ## Integration with other languages, frameworks
 


### PR DESCRIPTION
Adds the [parcel-plugin-inliner](https://github.com/shff/parcel-plugin-inliner/) to the list.

This plugin uses the [inliner](https://github.com/remy/inliner) package to concatenate all the JS, CSS and images used by an HTML file into the HTML file itself. It is great for minimal websites where loading speed is paramount.

Let me know if there's anything I can do to improve my description... or even if my plugin is not a fit for this list. Thanks in advance guys!