### PR TITLE
Add PurifyCSS

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -83,6 +83,7 @@
 - [web-extension](https://github.com/kevincharm/parcel-plugin-web-extension) - Plugin that enables to use a WebExtension `manifest.json` as an entry point.
 - [Static Files Copy](https://github.com/elwin013/parcel-plugin-static-files-copy) - Plugin that copy static files into bundle directory.
 - [Inliner](https://github.com/shff/parcel-plugin-inliner) - Inlines all your CSS, JS and images in a single HTML file. Great for small websites.
+- [PurifyCSS](https://github.com/shff/parcel-plugin-purifycss) - Removes unused selectors from your CSS files using [PurifyCSS](https://github.com/purifycss/purifycss).
 
 ## Integration with other languages, frameworks
 


### PR DESCRIPTION
This PR adds [parcel-plugin-purifycss](https://github.com/shff/parcel-plugin-purifycss/) to the list.

This plugin uses PurifyCSS to remove unused CSS selectors from your CSS files.