### PR TITLE
Add parcel-plugin-handlebars-precompile

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -51,6 +51,7 @@
 - [Mustache](https://github.com/suuzee/parcel-plugin-mustache) - Plugin for Mustache template support.
 - [Nunjucks](https://github.com/devmattrick/parcel-plugin-nunjucks) - Plugin to compile Nunjucks templates.
 - [Handlebars](https://github.com/TheBlackBolt/parcel-plugin-handlebars) - Plugin to compile handlebars templates.
+- [Handlebars precompile](https://github.com/belicekm/parcel-plugin-handlebars-precompile) - Plugin to precompile handlebars templates into template functions.
 
 ### Frameworks
 


### PR DESCRIPTION
Adds parcel-plugin-handlebars-precompile to the list of plugins.

The plugin can be used to import handlebars templates into javascript as a precompiled handlebars function.