### PR TITLE
Add link to parcel-plugin-md-fm

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -48,6 +48,7 @@
 - [Pug](https://github.com/Ty3uK/parcel-plugin-pug) - Pug template support.
 - [Markdown](https://github.com/gongpeione/parcel-plugin-markdown) - Plugin for markdown support.
 - [Markdown String](https://github.com/jaywcjlove/parcel-plugin-markdown-string) - Plugin for markdown string support.
+- [Markdown with Frontmatter](https://github.com/umstek/parcel-plugin-md-fm) - Plugin for markdown with frontmatter support.
 - [Mustache](https://github.com/suuzee/parcel-plugin-mustache) - Plugin for Mustache template support.
 - [Nunjucks](https://github.com/devmattrick/parcel-plugin-nunjucks) - Plugin to compile Nunjucks templates.
 - [Handlebars](https://github.com/TheBlackBolt/parcel-plugin-handlebars) - Plugin to compile handlebars templates.


### PR DESCRIPTION
This plugin supports loading various markdown front-matter formats using `gray-matter`. 