### PR TITLE
Add parcel-plugin-ogimage

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -107,6 +107,7 @@
 - [Structurize](https://www.npmjs.com/package/parcel-plugin-structurize) Structurize the build directory using glob matching and update paths as well.
 - [parcel-plugin-run-server](https://github.com/qualitybath/parcel-plugin-run-server) Start (and restart) a node server while running in watch mode.
 - [parcel-plugin-prerender](https://github.com/ABuffSeagull/parcel-plugin-prerender) Drop-in universal pre-rendering.
+- [parcel-plugin-ogimage](https://github.com/lukechilds/parcel-plugin-ogimage) Set absolute URL for og:image meta tags.
 
 ## Integration with other languages, frameworks
 


### PR DESCRIPTION
https://github.com/lukechilds/parcel-plugin-ogimage

Sets absolute URLs for `og:image` meta tags. This is required by the spec and relative URLs will not work on some sites such as Twitter.

You can fix this directly in parcel by using `--public-url https://example.com`, however now all your URLs are hardcoded to absolute URLs which may be undesirable and can break things like prerendering.

This plugin uses the value of the `og:url` meta tag to convert `og:image` to an absolute URL.