### PR TITLE
adds parcel-plugin-goodie-bag to "other"

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -108,6 +108,7 @@
 - [parcel-plugin-run-server](https://github.com/qualitybath/parcel-plugin-run-server) Start (and restart) a node server while running in watch mode.
 - [parcel-plugin-prerender](https://github.com/ABuffSeagull/parcel-plugin-prerender) Drop-in universal pre-rendering.
 - [parcel-plugin-ogimage](https://github.com/lukechilds/parcel-plugin-ogimage) Set absolute URL for og:image meta tags.
+- [parcel-plugin-goodie-bag](https://github.com/edm00se/parcel-plugin-goodie-bag/) Automatically polyfill `Promise` and `fetch` for Internet Explorer (11) support of importing HTML.
 
 ## Integration with other languages, frameworks
 


### PR DESCRIPTION
This supports the issue as described in parcel-bundler/website#452. The plugin automates the necessary inclusion of the polyfills for `Promise` and `fetch` early enough in the browser load to allow the successful importing of HTML in Internet Explorer (11).

Package links:
- on GitHub: https://github.com/edm00se/parcel-plugin-goodie-bag/
- on npm: https://npmjs.com/package/parcel-plugin-goodie-bag