### PR TITLE
added parcel-plugin-obfuscate plugin to list

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -113,6 +113,7 @@
 - [parcel-plugin-subresource-integrity](https://github.com/jonathannen/parcel-plugin-subresource-integrity/) Adds Subresource `integrity` attributes to the HTML entry point for CSS and JS assets.
 - [CSS Modules](https://github.com/rfgamaral/parcel-plugin-typings-for-css-modules) Plugin to generate `.d.ts` (TypeScript type definitions) files for your CSS Modules, powered by [@Quramy/typed-css-modules](https://github.com/Quramy/typed-css-modules).
 - [parcel-plugin-overwolf](https://github.com/sammccord/parcel-plugin-overwolf) Plugin that enables use of [Overwolf's `manifest.json`](http://developers.overwolf.com/documentation/sdk/overwolf/manifest-json/)
+- [code obfuscation](https://github.com/jabuco/parcel-plugin-obfuscate) Plugin that uses [`javascript-obfuscate`](https://github.com/javascript-obfuscator/javascript-obfuscator/) to obfuscate javascript code of entry assets.
 
 ## Integration with other languages, frameworks
 


### PR DESCRIPTION
this plugin adds obfuscation to built javascript assets. this can be useful if source code shouldn't be readable at first glance and debuggability should be made harder.