### PR TITLE
Add RadValentin/parcel-plugin-nuke-dist

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -121,6 +121,7 @@
 - [Linaria CSS-in-JS](https://github.com/callstack/parcel-plugin-linaria) Plugin to use Linaria library.
 - [parcel-plugin-codgen](https://github.com/FlorianRappl/parcel-plugin-codegen) - Allows to generate modules on the fly, i.e., a Node.js solution for metaprogramming modules.
 - [parcel-plugin-externals](https://github.com/FlorianRappl/parcel-plugin-externals) - Adds the ability to omit specified dependencies from the generated bundle(s), e.g., by referencing global variables.
+- [parcel-plugin-nuke-dist](https://github.com/RadValentin/parcel-plugin-nuke-dist) - Wipes the `dist/` directory before compiling a new bundle.
 
 ## Integration with other languages, frameworks
 


### PR DESCRIPTION
Plugin to wipe `dist/` directory before compiling a new bundle

https://github.com/RadValentin/parcel-plugin-nuke-dist