### PR TITLE
Fix redirects causing tests to fail

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -83,7 +83,7 @@
 - [AppCache](https://github.com/pierredavidbelanger/parcel-plugin-appcache) - Plugin for generating an appcache manifest.
 - [parcel-plugin-sw-cache](https://github.com/mischnic/parcel-plugin-sw-cache) - Run workbox-build after every build.
 - [Inline SVG](https://github.com/albinotonnina/parcel-plugin-inlinesvg) - Plugin that enables inline svg support. (deprecated)
-- [SVGR](https://github.com/smooth-code/svgr/tree/master/packages/parcel-plugin-svgr) - Plugin that imports svgs as components.
+- [SVGR](https://github.com/gregberge/svgr/tree/master/packages/parcel-plugin-svgr) - Plugin that imports svgs as components.
 - [SVG Sprite](https://github.com/Epimodev/parcel-plugin-svg-sprite) - Plugin that generates a sprite of imported svg files.
 - [Wrapper](https://github.com/albinotonnina/parcel-plugin-wrapper) - Plugin that wraps output files with custom text or code.
 - [Url-Loader](https://github.com/fansenze/parcel-plugin-url-loader) - Plugin that enables convert image to base64 in `js`/`css`.
@@ -93,7 +93,7 @@
 - [Bundle Visualiser](https://github.com/gregtillbrook/parcel-plugin-bundle-visualiser) - Plugin to visualise bundle contents (the parcel version of webpacks [webpack-bundle-analyzer](https://www.npmjs.com/package/webpack-bundle-analyzer))
 - [css to style object](https://www.npmjs.com/package/parcel-plugin-css-object) import css as object
 - [SW Precache](https://github.com/cyyyu/parcel-plugin-sw-precache) Plugin to generate a service worker file that will precache resources so they work offline. (PWA)
-- [PWA Manifest](https://github.com/101arrowz/parcel-plugin-pwa-manifest) Plugin that creates a web app manifest, generating a full icon set from a single image, and inserts links into the HTML for use in PWAs.
+- [PWA Manifest](https://github.com/101arrowz/pwa-manifest/tree/master/packages/parcel-plugin-pwa-manifest) Plugin that creates a web app manifest, generating a full icon set from a single image, and inserts links into the HTML for use in PWAs.
 - [react-native-web](https://github.com/dalcib/parcel-plugin-react-native-web) - Plugin that enables [react-native-web](https://github.com/necolas/react-native-web) support.
 - [web-extension](https://github.com/kevincharm/parcel-plugin-web-extension) - Plugin that enables to use a WebExtension `manifest.json` as an entry point.
 - [Static Files Copy](https://github.com/elwin013/parcel-plugin-static-files-copy) - Plugin that copies static files into bundle directory.


### PR DESCRIPTION
PR tests were failing because two Github repos have been moved to new urls (ownership was transferred or repo was renamed). Updated the URLs so the tests pass again and new PRs can be submitted. Existing PRs will need to have master merged to them so the changes are picked up.