### PR TITLE
Add parcel-plugin-marked-prismjs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -122,6 +122,7 @@
 - [parcel-plugin-codgen](https://github.com/FlorianRappl/parcel-plugin-codegen) - Allows to generate modules on the fly, i.e., a Node.js solution for metaprogramming modules.
 - [parcel-plugin-externals](https://github.com/FlorianRappl/parcel-plugin-externals) - Adds the ability to omit specified dependencies from the generated bundle(s), e.g., by referencing global variables.
 - [parcel-plugin-nuke-dist](https://github.com/RadValentin/parcel-plugin-nuke-dist) - Wipes the `dist/` directory before compiling a new bundle.
+- [parcel-plugin-marked-prismjs](https://github.com/hemmingson/parcel-plugin-marked-prismjs) - Plugin for using prismjs plugins in md files.
 
 ## Integration with other languages, frameworks
 


### PR DESCRIPTION
Add [parcel-plugin-marked-prismjs](https://github.com/hemmingson/parcel-plugin-marked-prismjs) to `Plugins/Other`.

This is a plugin for easily integrating with prismjs plugins by custom marked renderer.